### PR TITLE
fix: close workspace-rule race

### DIFF
--- a/src/core/events.c
+++ b/src/core/events.c
@@ -146,8 +146,8 @@ gf_wm_watch (gf_wm_t *m)
             else
             {
                 win->workspace_id = existing->workspace_id;
-                strncpy (win->name, existing->name, sizeof (win->name) - 1);
-                win->name[sizeof (win->name) - 1] = '\0';
+                gf_wm_resolve_window_name (m, win->id, existing->name, win->name,
+                                          sizeof (win->name));
 
                 const gf_window_rule_t *rule = gf_rules_find (m->config, win->name);
 

--- a/src/core/events.c
+++ b/src/core/events.c
@@ -147,7 +147,7 @@ gf_wm_watch (gf_wm_t *m)
             {
                 win->workspace_id = existing->workspace_id;
                 gf_wm_resolve_window_name (m, win->id, existing->name, win->name,
-                                          sizeof (win->name));
+                                           sizeof (win->name));
 
                 const gf_window_rule_t *rule = gf_rules_find (m->config, win->name);
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -62,6 +62,24 @@ gf_wm_window_class (const gf_wm_t *m, gf_handle_t handle, char *buffer, size_t s
         snprintf (buffer, size, "N/A");
 }
 
+/* Use cached_name if it was already resolved; otherwise re-query the
+ * platform. Callers pass NULL/"" for a never-seen window (always queries),
+ * or a previous name for a tracked window whose class may have arrived
+ * late (e.g. GTK apps that set WM_CLASS a moment after mapping). */
+void
+gf_wm_resolve_window_name (const gf_wm_t *m, gf_handle_t handle, const char *cached_name,
+                           char *out_name, size_t out_size)
+{
+    if (cached_name && cached_name[0] != '\0')
+    {
+        strncpy (out_name, cached_name, out_size - 1);
+        out_name[out_size - 1] = '\0';
+        return;
+    }
+
+    gf_wm_window_class (m, handle, out_name, out_size);
+}
+
 gf_monitor_id_t
 find_active_monitor (gf_wm_t *m)
 {

--- a/src/core/wm.h
+++ b/src/core/wm.h
@@ -63,6 +63,8 @@ void gf_wm_prune (gf_wm_t *manager);
 gf_err_t gf_wm_window_move (gf_wm_t *m, gf_handle_t window_id,
                             gf_ws_id_t target_workspace);
 void gf_wm_window_class (const gf_wm_t *m, gf_handle_t handle, char *buffer, size_t size);
+void gf_wm_resolve_window_name (const gf_wm_t *m, gf_handle_t handle,
+                                const char *cached_name, char *out_name, size_t out_size);
 gf_err_t gf_wm_window_sync (gf_wm_t *manager, gf_handle_t window,
                             gf_ws_id_t workspace_id);
 

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -215,11 +215,35 @@ switch_workspace (gf_wm_t *m, gf_ws_id_t current_workspace)
     }
 }
 
+/* Ensure every rule's target workspace exists and is flagged has_rule=true
+ * immediately, rather than waiting for its app to actually appear. Without
+ * this, a workspace reserved for a rule looks like ordinary free space to
+ * lookup_or_create_ws/gf_workspace_list_find_free until the first matching
+ * window is placed, letting an unrelated window claim it first. */
+static void
+create_rule_workspaces (gf_wm_t *m)
+{
+    gf_ws_list_t *workspaces = wm_workspaces (m);
+    uint32_t max_per_ws = m->config->max_windows_per_workspace;
+
+    for (uint32_t i = 0; i < m->config->window_rules_count; i++)
+    {
+        gf_ws_id_t rule_ws = m->config->window_rules[i].workspace_id;
+        gf_workspace_list_ensure (workspaces, rule_ws, max_per_ws);
+
+        gf_ws_info_t *ws = gf_workspace_list_find_by_id (workspaces, rule_ws);
+        if (ws)
+            ws->has_rule = true;
+    }
+}
+
 void
 sync_workspaces (gf_wm_t *m)
 {
     if (!m || !m->config)
         return;
+
+    create_rule_workspaces (m);
 
     gf_ws_list_t *workspaces = wm_workspaces (m);
     gf_platform_t *platform = wm_platform (m);
@@ -240,19 +264,6 @@ sync_workspaces (gf_wm_t *m)
             = ws->has_rule ? true : gf_config_workspace_is_locked (m->config, i);
         ws->max_windows = max_per_ws;
         ws->available_space = ws->is_locked ? 0 : (max_per_ws - ws->window_count);
-    }
-}
-
-static void
-create_rule_workspaces (gf_wm_t *m)
-{
-    gf_ws_list_t *workspaces = wm_workspaces (m);
-    uint32_t max_per_ws = m->config->max_windows_per_workspace;
-
-    for (uint32_t i = 0; i < m->config->window_rules_count; i++)
-    {
-        gf_ws_id_t rule_ws = m->config->window_rules[i].workspace_id;
-        gf_workspace_list_ensure (workspaces, rule_ws, max_per_ws);
     }
 }
 
@@ -424,6 +435,15 @@ assign_maximized_window (gf_wm_t *m, gf_win_info_t *win)
 {
     win->is_maximized = true;
     win->workspace_id = lookup_or_create_maximized_ws (m);
+
+    // Claim the slot immediately: the window isn't in the tracked list yet
+    // (that happens later in finalize_window_registration), so
+    // recount_workspace_windows won't see it until the end of this tick.
+    // Without this, several already-maximized windows discovered in the
+    // same tick would all see window_count == 0 and pile onto one workspace.
+    gf_ws_info_t *ws = gf_workspace_list_find_by_id (wm_workspaces (m), win->workspace_id);
+    if (ws)
+        ws->window_count++;
 }
 
 static void
@@ -497,10 +517,7 @@ register_new_window (gf_wm_t *m, gf_win_info_t *win, gf_ws_info_t *current_ws)
     gf_platform_t *platform = wm_platform (m);
     gf_display_t display = *wm_display (m);
 
-    char class_name[256];
-    gf_wm_window_class (m, win->id, class_name, sizeof (class_name));
-    strncpy (win->name, class_name, sizeof (win->name) - 1);
-    win->name[sizeof (win->name) - 1] = '\0';
+    gf_wm_resolve_window_name (m, win->id, NULL, win->name, sizeof (win->name));
 
     if (platform->window_is_maximized && platform->window_is_maximized (display, win->id))
     {
@@ -519,7 +536,7 @@ register_new_window (gf_wm_t *m, gf_win_info_t *win, gf_ws_info_t *current_ws)
         current_ws->is_custom_layout = false;
 
     GF_LOG_INFO ("New window %p → workspace %u (%s)", (void *)win->id, win->workspace_id,
-                 class_name);
+                 win->name);
 
     finalize_window_registration (m, win);
 }

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -441,7 +441,8 @@ assign_maximized_window (gf_wm_t *m, gf_win_info_t *win)
     // recount_workspace_windows won't see it until the end of this tick.
     // Without this, several already-maximized windows discovered in the
     // same tick would all see window_count == 0 and pile onto one workspace.
-    gf_ws_info_t *ws = gf_workspace_list_find_by_id (wm_workspaces (m), win->workspace_id);
+    gf_ws_info_t *ws
+        = gf_workspace_list_find_by_id (wm_workspaces (m), win->workspace_id);
     if (ws)
         ws->window_count++;
 }

--- a/src/platform/unix/window.c
+++ b/src/platform/unix/window.c
@@ -153,7 +153,8 @@ window_is_self (gf_display_t display, gf_handle_t window)
 
     bool match
         = (class_hint.res_name && strcmp (class_hint.res_name, "gridflux-gui") == 0)
-          || (class_hint.res_class && strstr (class_hint.res_class, "com.gridflux.gui") != NULL);
+          || (class_hint.res_class
+              && strstr (class_hint.res_class, "com.gridflux.gui") != NULL);
 
     if (class_hint.res_name)
         XFree (class_hint.res_name);

--- a/src/platform/unix/window.c
+++ b/src/platform/unix/window.c
@@ -6,6 +6,7 @@
 #include "internal.h"
 #include <X11/Xatom.h>
 #include <X11/Xutil.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
@@ -143,16 +144,23 @@ window_is_self (gf_display_t display, gf_handle_t window)
     if (!display || window == None)
         return false;
 
-    char class_name[256] = { 0 };
-    gf_window_get_class (display, window, class_name, sizeof (class_name));
+    // Check res_name/res_class individually (not via gf_window_get_class,
+    // which concatenates both for rule matching) so this exact-identity
+    // check can't be thrown off by whatever the other half contains.
+    XClassHint class_hint = { NULL, NULL };
+    if (!XGetClassHint (display, window, &class_hint))
+        return false;
 
-    if (strcmp (class_name, "gridflux-gui") == 0
-        || strstr (class_name, "com.gridflux.gui") != NULL)
-    {
-        return true;
-    }
+    bool match
+        = (class_hint.res_name && strcmp (class_hint.res_name, "gridflux-gui") == 0)
+          || (class_hint.res_class && strstr (class_hint.res_class, "com.gridflux.gui") != NULL);
 
-    return false;
+    if (class_hint.res_name)
+        XFree (class_hint.res_name);
+    if (class_hint.res_class)
+        XFree (class_hint.res_class);
+
+    return match;
 }
 
 bool
@@ -390,20 +398,23 @@ gf_window_get_class (gf_display_t dpy, gf_handle_t win, char *buffer, size_t buf
 
     buffer[0] = '\0';
 
-    XClassHint class_hint;
-    if (XGetClassHint (dpy, win, &class_hint))
-    {
-        if (class_hint.res_name)
-        {
-            strncpy (buffer, class_hint.res_name, bufsize - 1);
-            buffer[bufsize - 1] = '\0';
-            XFree (class_hint.res_name);
-        }
-        if (class_hint.res_class)
-        {
-            XFree (class_hint.res_class);
-        }
-    }
+    XClassHint class_hint = { NULL, NULL };
+    if (!XGetClassHint (dpy, win, &class_hint))
+        return;
+
+    // WM_CLASS has two parts (instance, class); which one carries the
+    // identifier a rule targets varies by app (e.g. GTK apps commonly leave
+    // the reverse-DNS id, like "org.gnome.Nautilus", only in res_class).
+    // Concatenate both so rule matching can find either.
+    const char *name = class_hint.res_name ? class_hint.res_name : "";
+    const char *cls = class_hint.res_class ? class_hint.res_class : "";
+    const char *sep = (name[0] && cls[0]) ? " " : "";
+    snprintf (buffer, bufsize, "%s%s%s", name, sep, cls);
+
+    if (class_hint.res_name)
+        XFree (class_hint.res_name);
+    if (class_hint.res_class)
+        XFree (class_hint.res_class);
 }
 
 bool


### PR DESCRIPTION
- Reserve rule-target workspaces (has_rule) as soon as they're created instead of after their first matching window arrives, so an unruled window can no longer claim the workspace before the intended app appears.
- Read both WM_CLASS fields when matching rules, since apps such as org.gnome.Nautilus often carry their identifier in res_class only, which was previously discarded.
- Re-resolve a window's class if it was empty on first sight instead of permanently caching the empty name.
- Check res_name/res_class independently in window_is_self so the GridFlux GUI's own exclusion check isn't broken by the WM_CLASS matching change above.
- Claim a maximized window's workspace slot immediately on assignment so multiple already-maximized windows discovered in the same tick don't all pile onto one workspace.